### PR TITLE
Reduce Guesthouse log verbosity via configurable log level

### DIFF
--- a/guesthouse/app.py
+++ b/guesthouse/app.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import os
 import secrets
 
 from fastapi import Body, FastAPI
@@ -25,7 +26,8 @@ background_tasks = {}
 
 @app.on_event("startup")
 async def configure_logging() -> None:
-    logging.basicConfig(level=logging.INFO)
+    level = os.getenv("LOG_LEVEL", "WARNING").upper()
+    logging.basicConfig(level=getattr(logging, level, logging.WARNING))
 
 
 @app.on_event("startup")


### PR DESCRIPTION
- Replace fixed logging.basicConfig(level=logging.INFO) in startup event with dynamic configuration based on LOG_LEVEL environment variable
- Default log level is now WARNING, reducing noisy logs in production
- Allows easy adjustment of logging verbosity per environment without code changes

Tested on the production server